### PR TITLE
WPP-56

### DIFF
--- a/src/main/java/org/jasig/portlet/proxy/service/IContentService.java
+++ b/src/main/java/org/jasig/portlet/proxy/service/IContentService.java
@@ -36,7 +36,14 @@ public interface IContentService<T extends IContentRequest, S extends IContentRe
 	 * @return
 	 */
 	public T getRequest(PortletRequest request);
-	
+
+    /**
+     * Execute any necessary logic prior to retrieving the content
+     * @param contentRequest
+     * @param request
+     */
+    public void beforeGetContent(T contentRequest, PortletRequest request);
+
 	/**
 	 * Retrieve content for the given content request and portlet request.
 	 * 
@@ -46,4 +53,10 @@ public interface IContentService<T extends IContentRequest, S extends IContentRe
 	 */
     public S getContent(T contentRequest, PortletRequest request);
 
+    /**
+     * Execute any necessary logic after retrieving the content
+     * @param contentRequest
+     * @param request
+     */
+    public void afterGetContent(T contentRequest, PortletRequest request, S proxyResponse);
 }

--- a/src/main/java/org/jasig/portlet/proxy/service/web/CachingHttpContentServiceImpl.java
+++ b/src/main/java/org/jasig/portlet/proxy/service/web/CachingHttpContentServiceImpl.java
@@ -1,0 +1,88 @@
+/**
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.portlet.proxy.service.web;
+
+import net.sf.ehcache.Cache;
+import net.sf.ehcache.Element;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.jasig.portlet.proxy.service.GenericContentResponseImpl;
+import org.jasig.portlet.proxy.service.IContentResponse;
+import org.jasig.portlet.proxy.service.IContentService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Required;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.Resource;
+import javax.portlet.PortletRequest;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+@Service("httpContentService")
+public class CachingHttpContentServiceImpl extends HttpContentServiceImpl {
+    private static final Log LOG = LogFactory.getLog(CachingHttpContentServiceImpl.class);
+
+    private Cache cache;
+
+
+    public CachingHttpContentServiceImpl() {
+    }
+
+    @Required
+    @Resource(name="urlCache")
+    public void setCache(Cache cache) {
+        this.cache = cache;
+    }
+
+    @Override
+    public GenericContentResponseImpl getContent(HttpContentRequestImpl proxyRequest, PortletRequest request) {
+        GenericContentResponseImpl response = null;
+        super.beforeGetContent(proxyRequest, request);
+        String cacheKey = proxyRequest.getProxiedLocation();
+        Element cachedElement = cache.get(cacheKey);
+        if (cachedElement == null) {
+            if(LOG.isDebugEnabled()) {
+                LOG.debug("Cache miss");
+            }
+            response = super.getContent(proxyRequest, request, false);
+            try {
+                response.setContent(new ByteArrayInputStream(IOUtils.toByteArray(response.getContent())));
+                cachedElement = new Element(cacheKey, response);
+                cache.put(cachedElement);
+            } catch(IOException ioexception) {
+                LOG.error("Exception retrieving remote content", ioexception);
+            }
+        } else {
+            if(LOG.isDebugEnabled()) {
+                LOG.debug("Cache hit");
+            }
+            response = (GenericContentResponseImpl)cachedElement.getValue();
+            try {
+                response.getContent().reset();
+            } catch(IOException ioException) {
+                LOG.error("Error retrieving cached page. Resending request...");
+                cache.remove(cacheKey);
+                return this.getContent(proxyRequest, request);
+            }
+        }
+
+        return response;
+    }
+}

--- a/src/main/java/org/jasig/portlet/proxy/service/web/HttpContentResponseImpl.java
+++ b/src/main/java/org/jasig/portlet/proxy/service/web/HttpContentResponseImpl.java
@@ -18,6 +18,7 @@
  */
 package org.jasig.portlet.proxy.service.web;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -25,11 +26,11 @@ import org.apache.http.HttpEntity;
 import org.apache.http.util.EntityUtils;
 import org.jasig.portlet.proxy.service.GenericContentResponseImpl;
 
-public class HttpContentResponseImpl extends GenericContentResponseImpl {
+public class HttpContentResponseImpl extends GenericContentResponseImpl implements Serializable {
 
 	private Map<String, String> headers = new HashMap<String, String>();
-	
-	private HttpEntity entity;
+
+	private transient HttpEntity entity;
 	
 	public HttpContentResponseImpl(HttpEntity entity) {
 		this.entity = entity;

--- a/src/main/webapp/WEB-INF/context/applicationContext.xml
+++ b/src/main/webapp/WEB-INF/context/applicationContext.xml
@@ -32,6 +32,14 @@
     <context:component-scan base-package="org.jasig.portlet.proxy.service"/>
     <context:annotation-config/>
 
+    <!-- EHCache Configuration -->
+    <bean id="cacheManager" class="org.springframework.cache.ehcache.EhCacheManagerFactoryBean"
+          p:configLocation="classpath:ehcache.xml"/>
+
+    <bean id="urlCache"
+          class="org.springframework.cache.ehcache.EhCacheFactoryBean"
+          p:cacheManager-ref="cacheManager" p:cacheName="urlCache"/>
+
     <bean
         class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
         <property name="location" value="classpath:configuration.properties" />


### PR DESCRIPTION
Add caching for http requests through the new CachingHttpContentServiceImpl class which extends the previous HttpContentServiceImpl class. If caching is not desired simply move the @Service tag back to the old class.
