### PR TITLE
WPP-69

### DIFF
--- a/src/main/java/org/jasig/portlet/proxy/security/JasyptPBEStringEncryptionServiceImpl.java
+++ b/src/main/java/org/jasig/portlet/proxy/security/JasyptPBEStringEncryptionServiceImpl.java
@@ -21,10 +21,13 @@ package org.jasig.portlet.proxy.security;
 
 import org.jasypt.encryption.pbe.PBEStringEncryptor;
 import org.jasypt.exceptions.EncryptionInitializationException;
+import org.jasypt.exceptions.EncryptionOperationNotPossibleException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Required;
 import org.springframework.util.Assert;
+
+import javax.annotation.PostConstruct;
 
 /**
  * JasyptPBEStringEncryptionServiceImpl is an implementation of 
@@ -33,72 +36,89 @@ import org.springframework.util.Assert;
  * 
  * @author Jen Bourey
  */
-public class JasyptPBEStringEncryptionServiceImpl implements IStringEncryptionService, InitializingBean {
+public class JasyptPBEStringEncryptionServiceImpl implements IStringEncryptionService {
     protected final Logger logger = LoggerFactory.getLogger(this.getClass());
 
-	private PBEStringEncryptor encryptor = null;
-	
-	/**
-	 * Set the PBEStringEncryptor to be used
-	 * 
-	 * @param encryptor
-	 */
-	public void setStringEncryptor(final PBEStringEncryptor encryptor) {
-		this.encryptor = encryptor;
-	}
-	
-	/**
-	 * {@inheritDoc}
-	 */
-	public String encrypt(final String plaintext) {
-		if (this.encryptor == null) {
-			logger.error("encryptor not set");
-            return null;
-		}
+    private PBEStringEncryptor encryptor = null;
+    
+    /**
+     * Set the PBEStringEncryptor to be used
+     * 
+     * @param encryptor
+     */
+    @Required
+    public void setStringEncryptor(final PBEStringEncryptor encryptor) {
+        this.encryptor = encryptor;
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    public String encrypt(final String plaintext) {
         try {
             return this.encryptor.encrypt(plaintext);
         } catch (EncryptionInitializationException e) {
             logger.warn(e.getMessage(), e);
             throw new StringEncryptionException("Encryption error. Verify an encryption password"
-                    + " is configured in the email preview portlet's"
-                    + " stringEncryptionService bean in applicationContent.xml", e);
+                    + " is configured in configuration.properties", e);
         }
-	}
-	
-	/**
-	 * {@inheritDoc}
-	 */
-	public String decrypt(final String cryptotet) {
-		if (this.encryptor == null) {
-			logger.error("encryptor not set");
-            return null;
-		}
-      try {
-	        return this.encryptor.decrypt(cryptotet);
-      } catch (EncryptionInitializationException e) {
-    	  logger.warn(e.getMessage(), e);
-          throw new StringEncryptionException("Decryption error. Was encryption password"
-                  + " changed in the email preview portlet's"
-                  + " stringEncryptionService bean in applicationContent.xml?", e);
-      }
+    }
+    
+    private String decrypt(final String cryptotext, boolean logError) {
+        try {
+            return this.encryptor.decrypt(cryptotext);
+        } catch (EncryptionInitializationException e) {
+            if (logError) {
+                logger.warn("Decryption failed.  Error message: {}", e.getMessage());
+            }
+            throw new StringEncryptionException("Decryption error. Was encryption password"
+                        + " changed in the configuration.properties?", e);
+        } catch (EncryptionOperationNotPossibleException e) {
+            if (logError) {
+                logger.warn("Decryption failed.  This suggests the salt key in "
+                        + "configuration.properties has been changed.");
+            }
+            throw new StringEncryptionException("Decryption error. Was encryption password"
+                        + " changed in the configuration.properties?", e);
+        }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
+    public String decrypt(final String cryptotext) {
+        return decrypt(cryptotext, true);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @PostConstruct
     public void afterPropertiesSet() throws Exception {
         final String enc = this.encrypt(this.getClass().getName());
         Assert.notNull(enc, "String encryption service is not properly configured.");
-        
+
         final String dec = this.decrypt(enc);
         Assert.notNull(dec, "String decryption service is not properly configured.");
         Assert.isTrue(dec.equals(this.getClass().getName()), "String decryption failed to decode the encrypted text " + enc);
+
         if (usingDefaultEncryptionKey()) {
             logger.error("Encryption key at default value.  Change it in configuration.properties for improved security!");
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean usingDefaultEncryptionKey() {
-        String result = this.decrypt("pD2vrJ0CiAbnW4k4lF84S8yXN6gSl6VUjISd8NN6AFnDGuei5rGyuw==");
-        return "EncryptionKeyStillchangeMe".equals(result);
+        try {
+            String result = this.decrypt("pD2vrJ0CiAbnW4k4lF84S8yXN6gSl6VUjISd8NN6AFnDGuei5rGyuw==", false);
+            return "EncryptionKeyStillchangeMe".equals(result);
+        } catch (StringEncryptionException e) {
+            // If encryption is being used, a decryption error is good because it means the encryption key was changed.
+            return false;
+        }
     }
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -24,3 +24,12 @@ edit.proxy.show.preferences.link=Configure Login Information
 edit.proxy.cancel=Cancel
 
 portlet.preferences.missing=(configure login information)
+
+## error.jsp
+error.message.refresh=Refresh
+error.message.first=ERROR! - Unable to retrieve information for Web Proxy Portlet!
+error.message.second=Please try again later.
+
+## pswEncError.jsp
+error.message.enc.first=Password encryption service has failed.
+error.message.enc.second=Make sure the <i>encryption password</i> is properly specified in configuration.properties and has not changed since you entered your password.

--- a/src/main/webapp/WEB-INF/context/applicationContext.xml
+++ b/src/main/webapp/WEB-INF/context/applicationContext.xml
@@ -34,6 +34,25 @@
     <context:component-scan base-package="org.jasig.portlet.proxy.service"/>
     <context:annotation-config/>
 
+    <bean id="exceptionResolver" class="org.springframework.web.portlet.handler.SimpleMappingExceptionResolver">
+        <!-- 
+         | Always declare an 'exceptionResolver' bean with a 'defaultErrorView' 
+         | because, in addition to other uses, it protects the portlet from 
+         | failing when a bad request (due to a bug or malicious user) doesn't 
+         | match any declared @RequestMapping.  When this happens, the portlet 
+         | throws an Exception and takes itself out of service until a portal 
+         | restart.  THIS CONDITION AFFECTS ALL USERS!
+         +-->
+         <property name="exceptionMappings">
+            <props>
+              <!-- Exception thrown when an error is raised during initialization, such as when 
+                   the encryption password is not set for password based encryptor  -->
+              <prop key="org.jasig.portlet.proxy.security.StringEncryptionException">pswEncError</prop>
+            </props>
+        </property>
+        <property name="defaultErrorView" value="error"/>
+    </bean>
+
     <!-- EHCache Configuration -->
     <bean id="cacheManager" class="org.springframework.cache.ehcache.EhCacheManagerFactoryBean"
           p:configLocation="classpath:ehcache.xml"/>

--- a/src/main/webapp/WEB-INF/context/portlet/gateway-sso-portlet.xml
+++ b/src/main/webapp/WEB-INF/context/portlet/gateway-sso-portlet.xml
@@ -57,13 +57,16 @@
               p:iconUrl="/ResourceServingWebapp/rs/tango/0.8.90/32x32/apps/internet-mail.png">
 
             <!- beans in list must implement org.jasig.portlet.proxy.mvc.service.web.ExternalLogic interface.  They
-                can add form fields based on custom logic, or modifying the url to submit to. ->
-            <property name="authenticationFormModifier">
+                can add form fields based on custom logic, or modifying the url to submit to.
+                This form modifier is not to be uncommented for Zimbra example
+             ->
+            <!- <property name="authenticationFormModifier">
                 <util:list>
-                    <bean id="step1" class="org.jasig.portlet.proxy.service.web.ExampleCustomFormModifierodifier"
+                    <bean id="step1" class="org.jasig.portlet.proxy.service.web.ExampleCustomFormModifier"
                           scope="session" p:fieldName="proxiedLocation"/>
                 </util:list>
             </property>
+             ->
 
             <property name="contentRequests">
                 <util:map>

--- a/src/main/webapp/WEB-INF/jsp/error.jsp
+++ b/src/main/webapp/WEB-INF/jsp/error.jsp
@@ -1,0 +1,27 @@
+<%--
+
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License. You may obtain a
+    copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on
+    an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+--%>
+<jsp:directive.include file="/WEB-INF/jsp/include.jsp"/>
+
+<div class="portlet-font">
+    <p><a href="<portlet:renderURL><portlet:param name="action" value="preview"/></portlet:renderURL>"><spring:message code="error.message.refresh"/></a></p>
+    <p class="portlet-msg-error"><spring:message code="error.message.first"/><br />
+        <spring:message code="error.message.second"/></p>
+</div>

--- a/src/main/webapp/WEB-INF/jsp/pswEncError.jsp
+++ b/src/main/webapp/WEB-INF/jsp/pswEncError.jsp
@@ -1,0 +1,29 @@
+<%--
+
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License. You may obtain a
+    copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on
+    an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+--%>
+<jsp:directive.include file="/WEB-INF/jsp/include.jsp"/>
+
+<div class="portlet-font">
+    <p><a href="<portlet:renderURL><portlet:param name="action" value="preview"/></portlet:renderURL>"><spring:message code="error.message.refresh"/></a></p>
+    <p class="portlet-msg-error">
+    	<spring:message code="error.message.enc.first"/><br />
+        <spring:message code="error.message.enc.second"/>
+    </p>
+</div>


### PR DESCRIPTION
- Updating to show error message in UI if encryption error occurs
- Adding catch all error page (mimicing emailplt)
- Updating comment in gateway config to indicate a bean that is not a part of the zimbra example
- Change security class to match EmailPreview's implementation
- Catches when encryption key is at default and logs ERROR message with no stack trace
- Exposes boolean indicating encryption key is at default value
- Uses annotation for bean initialization
