### PR TITLE
MMM-30 update to search for WPP, including GSA

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,11 @@
                 <artifactId>standard</artifactId>
                 <version>${jstl.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.jasig.portal</groupId>
+                <artifactId>uportal-search-api</artifactId>
+                <version>4.0.10</version>
+            </dependency>
 
             <!-- For sl4j/logback logging, see https://wiki.jasig.org/display/PLT/Logging+Best+Practices -->
             <dependency>
@@ -290,6 +295,11 @@
             <groupId>org.jasypt</groupId> 
             <artifactId>jasypt</artifactId>  
             <version>1.6</version>
+        </dependency>
+               
+        <dependency>
+            <groupId>org.jasig.portal</groupId>
+            <artifactId>uportal-search-api</artifactId>
         </dependency>
         
         <dependency>

--- a/src/main/java/org/jasig/portlet/proxy/mvc/portlet/proxy/ProxyPortletForm.java
+++ b/src/main/java/org/jasig/portlet/proxy/mvc/portlet/proxy/ProxyPortletForm.java
@@ -23,118 +23,118 @@ import java.beans.PropertyEditorSupport;
 
 public class ProxyPortletForm {
 
-  public static final String AUTHENTICATION_TYPE = "authType";
-    
-	enum ProxyAuthType {
-		NONE, CAS, BASIC;
-	}
-	
-  public static final class ProxyAuthTypeEditor extends PropertyEditorSupport {
-      @Override
-      public void setAsText(String text) {
-          ProxyAuthType value = ProxyAuthType.valueOf(text);
-          setValue(value);
-      }
-  }
+    public static final String AUTHENTICATION_TYPE = "authType";
 
-  private String contentService;
-	private String location;
+    enum ProxyAuthType {
+        NONE, CAS, BASIC;
+    }
+
+    public static final class ProxyAuthTypeEditor extends PropertyEditorSupport {
+        @Override
+        public void setAsText(String text) {
+            ProxyAuthType value = ProxyAuthType.valueOf(text);
+            setValue(value);
+        }
+    }
+
+    private String contentService;
+    private String location;
     private String pageCharacterEncodingFormat;
-	
-	// filters
-	private String whitelistRegexes; // TODO: support multiple whitelist entries
-	private String clippingSelector;
-	private String header;
-	private String footer;
-	
-	// authentication
-	private ProxyAuthType authType = ProxyAuthType.NONE;
-	private String usernameKey = "user.login.id";
-	private String passwordKey = "password";
-	
+
+    // filters
+    private String whitelistRegexes; // TODO: support multiple whitelist entries
+    private String clippingSelector;
+    private String header;
+    private String footer;
+
+    // authentication
+    private ProxyAuthType authType = ProxyAuthType.NONE;
+    private String usernameKey = "user.login.id";
+    private String passwordKey = "password";
+
     // strategies
     private String[] searchStrategies;
-    
-	// gsa
-	private String gsaHost;
-	private String gsaCollection;
-	private String gsaFrontend;
-	private String gsaWhitelistRegex;
-	
-	// anchor
-	private String anchorWhitelistRegex;
 
-	public String getContentService() {
-		return contentService;
-	}
+    // gsa
+    private String gsaHost;
+    private String gsaCollection;
+    private String gsaFrontend;
+    private String gsaWhitelistRegex;
 
-	public void setContentService(String contentService) {
-		this.contentService = contentService;
-	}
+    // anchor
+    private String anchorWhitelistRegex;
 
-	public String getLocation() {
-		return location;
-	}
+    public String getContentService() {
+        return contentService;
+    }
 
-	public void setLocation(String location) {
-		this.location = location;
-	}
+    public void setContentService(String contentService) {
+        this.contentService = contentService;
+    }
 
-	public String getClippingSelector() {
-		return clippingSelector;
-	}
+    public String getLocation() {
+        return location;
+    }
 
-	public String getWhitelistRegexes() {
-		return whitelistRegexes;
-	}
+    public void setLocation(String location) {
+        this.location = location;
+    }
 
-	public void setWhitelistRegexes(String whitelistRegexes) {
-		this.whitelistRegexes = whitelistRegexes;
-	}
+    public String getClippingSelector() {
+        return clippingSelector;
+    }
 
-	public void setClippingSelector(String clippingSelector) {
-		this.clippingSelector = clippingSelector;
-	}
+    public String getWhitelistRegexes() {
+        return whitelistRegexes;
+    }
 
-	public String getHeader() {
-		return header;
-	}
+    public void setWhitelistRegexes(String whitelistRegexes) {
+        this.whitelistRegexes = whitelistRegexes;
+    }
 
-	public void setHeader(String header) {
-		this.header = header;
-	}
+    public void setClippingSelector(String clippingSelector) {
+        this.clippingSelector = clippingSelector;
+    }
 
-	public String getFooter() {
-		return footer;
-	}
+    public String getHeader() {
+        return header;
+    }
 
-	public void setFooter(String footer) {
-		this.footer = footer;
-	}
+    public void setHeader(String header) {
+        this.header = header;
+    }
 
-	public ProxyAuthType getAuthType() {
-		return authType;
-	}
+    public String getFooter() {
+        return footer;
+    }
 
-	public void setAuthType(ProxyAuthType authType) {
-		this.authType = authType;
-	}
+    public void setFooter(String footer) {
+        this.footer = footer;
+    }
 
-	public String getUsernameKey() {
-		return usernameKey;
-	}
+    public ProxyAuthType getAuthType() {
+        return authType;
+    }
 
-	public void setUsernameKey(String usernameKey) {
-		this.usernameKey = usernameKey;
-	}
+    public void setAuthType(ProxyAuthType authType) {
+        this.authType = authType;
+    }
 
-	public String getPasswordKey() {
-		return passwordKey;
-	}
+    public String getUsernameKey() {
+        return usernameKey;
+    }
 
-	public void setPasswordKey(String passwordKey) {
-		this.passwordKey = passwordKey;
-	}
+    public void setUsernameKey(String usernameKey) {
+        this.usernameKey = usernameKey;
+    }
+
+    public String getPasswordKey() {
+        return passwordKey;
+    }
+
+    public void setPasswordKey(String passwordKey) {
+        this.passwordKey = passwordKey;
+    }
 
     public String getPageCharacterEncodingFormat() {
         return pageCharacterEncodingFormat;

--- a/src/main/java/org/jasig/portlet/proxy/mvc/portlet/proxy/ProxyPortletForm.java
+++ b/src/main/java/org/jasig/portlet/proxy/mvc/portlet/proxy/ProxyPortletForm.java
@@ -52,6 +52,17 @@ public class ProxyPortletForm {
 	private String usernameKey = "user.login.id";
 	private String passwordKey = "password";
 	
+    // strategies
+    private String[] searchStrategies;
+    
+	// gsa
+	private String gsaHost;
+	private String gsaCollection;
+	private String gsaFrontend;
+	private String gsaWhitelistRegex;
+	
+	// anchor
+	private String anchorWhitelistRegex;
 
 	public String getContentService() {
 		return contentService;
@@ -131,5 +142,53 @@ public class ProxyPortletForm {
 
     public void setPageCharacterEncodingFormat(String pageCharacterEncodingFormat) {
         this.pageCharacterEncodingFormat = pageCharacterEncodingFormat;
+    }
+
+    public String getGsaHost() {
+        return gsaHost;
+    }
+
+    public void setGsaHost(String gsaHost) {
+        this.gsaHost = gsaHost;
+    }
+
+    public String getGsaCollection() {
+        return gsaCollection;
+    }
+
+    public void setGsaCollection(String gsaCollection) {
+        this.gsaCollection = gsaCollection;
+    }
+
+    public String getGsaFrontend() {
+        return gsaFrontend;
+    }
+
+    public void setGsaFrontend(String gsaFrontend) {
+        this.gsaFrontend = gsaFrontend;
+    }
+
+    public String[] getSearchStrategies() {
+        return searchStrategies;
+    }
+
+    public void setSearchStrategies(String[] searchStrategies) {
+        this.searchStrategies = searchStrategies;
+    }
+
+    public String getGsaWhitelistRegex() {
+        return gsaWhitelistRegex;
+    }
+
+    public void setGsaWhitelistRegex(String gsaWhitelistRegex) {
+        this.gsaWhitelistRegex = gsaWhitelistRegex;
+    }
+
+    public String getAnchorWhitelistRegex() {
+        return anchorWhitelistRegex;
+    }
+
+    public void setAnchorWhitelistRegex(String anchorWhitelistRegex) {
+        this.anchorWhitelistRegex = anchorWhitelistRegex;
     }
 }

--- a/src/main/java/org/jasig/portlet/proxy/mvc/portlet/proxy/SearchProxyController.java
+++ b/src/main/java/org/jasig/portlet/proxy/mvc/portlet/proxy/SearchProxyController.java
@@ -1,0 +1,42 @@
+package org.jasig.portlet.proxy.mvc.portlet.proxy;
+
+import javax.annotation.Resource;
+import javax.portlet.Event;
+import javax.portlet.EventRequest;
+import javax.portlet.EventResponse;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.jasig.portal.search.SearchConstants;
+import org.jasig.portal.search.SearchRequest;
+import org.jasig.portal.search.SearchResults;
+import org.jasig.portlet.proxy.search.ISearchService;
+import org.springframework.beans.factory.annotation.Required;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.portlet.bind.annotation.EventMapping;
+
+@Controller
+@RequestMapping("VIEW")
+public class SearchProxyController {
+	protected final Logger log = LoggerFactory.getLogger(this.getClass());
+	
+	private ISearchService searchService;
+    @Required
+    @Resource(name="contentSearchProvider")
+    public void setSearchService(ISearchService searchService) {
+	    this.searchService = searchService;
+    }
+    
+	@EventMapping(SearchConstants.SEARCH_REQUEST_QNAME_STRING) 
+	public void searchRequest(EventRequest request, EventResponse response) {   
+        log.debug("EVENT HANDLER -- START");
+        final Event event = request.getEvent();
+        final SearchRequest searchQuery = (SearchRequest)event.getValue();
+        
+        SearchResults searchResults = searchService.search(searchQuery, request);
+        
+        response.setEvent(SearchConstants.SEARCH_RESULTS_QNAME, searchResults);
+        log.debug("EVENT HANDLER -- END");
+    }
+}

--- a/src/main/java/org/jasig/portlet/proxy/mvc/portlet/proxy/SearchProxyController.java
+++ b/src/main/java/org/jasig/portlet/proxy/mvc/portlet/proxy/SearchProxyController.java
@@ -19,23 +19,23 @@ import org.springframework.web.portlet.bind.annotation.EventMapping;
 @Controller
 @RequestMapping("VIEW")
 public class SearchProxyController {
-	protected final Logger log = LoggerFactory.getLogger(this.getClass());
-	
-	private ISearchService searchService;
+    protected final Logger log = LoggerFactory.getLogger(this.getClass());
+
+    private ISearchService searchService;
     @Required
     @Resource(name="contentSearchProvider")
     public void setSearchService(ISearchService searchService) {
-	    this.searchService = searchService;
+        this.searchService = searchService;
     }
-    
-	@EventMapping(SearchConstants.SEARCH_REQUEST_QNAME_STRING) 
-	public void searchRequest(EventRequest request, EventResponse response) {   
+
+    @EventMapping(SearchConstants.SEARCH_REQUEST_QNAME_STRING) 
+    public void searchRequest(EventRequest request, EventResponse response) {   
         log.debug("EVENT HANDLER -- START");
         final Event event = request.getEvent();
         final SearchRequest searchQuery = (SearchRequest)event.getValue();
-        
+
         SearchResults searchResults = searchService.search(searchQuery, request);
-        
+
         response.setEvent(SearchConstants.SEARCH_RESULTS_QNAME, searchResults);
         log.debug("EVENT HANDLER -- END");
     }

--- a/src/main/java/org/jasig/portlet/proxy/search/AnchorSearchStrategy.java
+++ b/src/main/java/org/jasig/portlet/proxy/search/AnchorSearchStrategy.java
@@ -1,0 +1,80 @@
+package org.jasig.portlet.proxy.search;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.Resource;
+import javax.portlet.EventRequest;
+import javax.portlet.PortletMode;
+import javax.portlet.WindowState;
+
+import org.jasig.portal.search.PortletUrl;
+import org.jasig.portal.search.PortletUrlParameter;
+import org.jasig.portal.search.PortletUrlType;
+import org.jasig.portal.search.SearchRequest;
+import org.jasig.portal.search.SearchResult;
+import org.jasig.portlet.proxy.search.util.SearchUtil;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Required;
+
+public class AnchorSearchStrategy implements ISearchStrategy {
+    protected final Logger log = LoggerFactory.getLogger(this.getClass());
+
+    private ISearchService contentSearchProvider;
+    @Required
+    @Resource(name="contentSearchProvider")
+    public void setContentSearchProvider(ISearchService contentSearchProvider) {
+        this.contentSearchProvider = contentSearchProvider;
+    }
+    
+    @PostConstruct
+    public void init() {
+        contentSearchProvider.addSearchStrategy(this);
+    }
+
+    @Override
+    public String getStrategyName() {
+        return "Anchor";
+    }
+
+    @Override
+    public List<SearchResult> search(SearchRequest searchQuery,
+            EventRequest request, Document document) {
+        List<SearchResult> results = new ArrayList<SearchResult>();
+        final String[] whitelistRegexes = request.getPreferences().getValues("anchorWhitelistRegex", new String[] {});
+        String searchTerms = searchQuery.getSearchTerms().toLowerCase();
+                
+        Elements links = document.select("a[href]");
+        for (Element link : links) {
+            String linkUrl = link.attr("abs:href");
+            for (String searchTerm: searchTerms.split(" ")) {
+                if (link.text().toLowerCase().contains(searchTerm)) {
+                    log.debug("found a match, term: [" + searchTerm + "], anchor URL: [" + linkUrl + "], anchor text: [" + link.text() + "]");
+                    SearchResult result = new SearchResult();
+                    result.setTitle(link.text());
+                    result.setSummary(link.text());
+                    
+                    PortletUrl pUrl = new PortletUrl();
+                    pUrl.setPortletMode(PortletMode.VIEW.toString());
+                    pUrl.setType(PortletUrlType.RENDER);
+                    pUrl.setWindowState(WindowState.MAXIMIZED.toString());
+                    PortletUrlParameter param = new PortletUrlParameter();
+                    param.setName("proxy.url");
+                    param.getValue().add(linkUrl);
+                    pUrl.getParam().add(param);
+
+                    new SearchUtil().updateUrls(linkUrl, request, whitelistRegexes);
+     
+                    result.setPortletUrl(pUrl);
+                    results.add(result);
+                }
+            }            
+        }        
+        return results;
+    }    
+}

--- a/src/main/java/org/jasig/portlet/proxy/search/DefaultSearchService.java
+++ b/src/main/java/org/jasig/portlet/proxy/search/DefaultSearchService.java
@@ -1,0 +1,58 @@
+package org.jasig.portlet.proxy.search;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.portlet.EventRequest;
+import javax.portlet.PortletPreferences;
+import org.jasig.portal.search.SearchRequest;
+import org.jasig.portal.search.SearchResult;
+import org.jasig.portal.search.SearchResults;
+import org.jasig.portlet.proxy.service.GenericContentRequestImpl;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DefaultSearchService implements ISearchService {
+    protected final Logger log = LoggerFactory.getLogger(this.getClass());
+
+    private Map<String, ISearchStrategy> strategies = new HashMap<String, ISearchStrategy>();
+    @Override
+    public void addSearchStrategy(ISearchStrategy strategy) {
+        strategies.put(strategy.getStrategyName(), strategy);
+    }
+    
+    public String[] getStrategyNames() {
+        return (String[]) strategies.keySet().toArray(new String[]{});
+    }
+    
+    @Override
+    public SearchResults search(SearchRequest searchQuery, EventRequest request) {
+        final SearchResults searchResults = new SearchResults();
+        searchResults.setQueryId(searchQuery.getQueryId());
+        searchResults.setWindowId(request.getWindowID());
+        
+        String baseUrl = request.getPreferences().getValue(
+                GenericContentRequestImpl.CONTENT_LOCATION_KEY, "/");
+        try {
+            Document document = Jsoup.connect(baseUrl).get();
+            final PortletPreferences preferences = request.getPreferences();
+            String[] strategyNames = preferences.getValues("searchStrategies", new String[]{});
+            for (int i = 0; i < strategyNames.length; i++) {
+                ISearchStrategy strategy = strategies.get(strategyNames[i]);
+                if (strategy != null) {
+                    List<SearchResult> results = strategy.search(searchQuery, request, document);
+                    searchResults.getSearchResult().addAll(results);
+                }
+            }
+        } catch (IOException e) {
+            log.error(e.getMessage(), e);
+        }
+        
+        return searchResults;
+
+    }
+}

--- a/src/main/java/org/jasig/portlet/proxy/search/GsaSearchStrategy.java
+++ b/src/main/java/org/jasig/portlet/proxy/search/GsaSearchStrategy.java
@@ -1,0 +1,147 @@
+package org.jasig.portlet.proxy.search;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.Resource;
+import javax.portlet.EventRequest;
+import javax.portlet.PortletMode;
+import javax.portlet.WindowState;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.impl.client.DecompressingHttpClient;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.jasig.portal.search.PortletUrl;
+import org.jasig.portal.search.PortletUrlParameter;
+import org.jasig.portal.search.PortletUrlType;
+import org.jasig.portal.search.SearchRequest;
+import org.jasig.portal.search.SearchResult;
+import org.jasig.portlet.proxy.search.util.SearchUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Required;
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
+
+public class GsaSearchStrategy implements ISearchStrategy {
+    protected final Logger log = LoggerFactory.getLogger(this.getClass());
+
+    private ISearchService contentSearchProvider;
+    @Required
+    @Resource(name="contentSearchProvider")
+    public void setContentSearchProvider(ISearchService contentSearchProvider) {
+        this.contentSearchProvider = contentSearchProvider;
+    }
+    
+    @PostConstruct
+    public void init() {
+        contentSearchProvider.addSearchStrategy(this);
+    }
+
+    @Override
+    public String getStrategyName() {
+        return "GSA";
+    }
+
+    @Override
+    public List<SearchResult> search(SearchRequest searchQuery,
+            EventRequest request, org.jsoup.nodes.Document ignore) {
+        
+        List<SearchResult> searchResults = new ArrayList<SearchResult>();
+        
+        String searchBaseURL = this.buildGsaUrl(searchQuery, request);
+        HttpClient client = new DecompressingHttpClient(new DefaultHttpClient());         
+        HttpGet get = new HttpGet(searchBaseURL);
+
+        try {
+            
+            HttpResponse httpResponse = client.execute(get);
+            log.debug("STATUS CODE :: "+httpResponse.getStatusLine().getStatusCode());
+            
+            InputStream in = httpResponse.getEntity().getContent();
+                        
+            DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
+            DocumentBuilder builder = docFactory.newDocumentBuilder();
+            
+            Document doc = builder.parse(in);
+            
+            log.debug(("GOT InputSource"));
+            XPathFactory  factory=XPathFactory.newInstance();
+            XPath xPath=factory.newXPath();
+                    
+            Integer maxCount = Integer.parseInt(xPath.evaluate("count(/GSP/RES/R)", doc));
+
+            final String[] whitelistRegexes = request.getPreferences().getValues("gsaWhitelistRegex", new String[] {});
+
+            log.debug(maxCount + " -- Results");
+            for (int count = 1; count <= maxCount; count++ ) {
+                String u = xPath.evaluate("/GSP/RES/R["+count+"]/U/text()", doc);
+                String t = xPath.evaluate("/GSP/RES/R["+count+"]/T/text()", doc);
+                String s = xPath.evaluate("/GSP/RES/R["+count+"]/S/text()", doc);
+                
+                log.debug("title: [" + t + "]");
+                SearchResult result = new SearchResult();
+                result.setTitle(t);
+                result.setSummary(s);
+                
+                PortletUrl pUrl = new PortletUrl();
+                pUrl.setPortletMode(PortletMode.VIEW.toString());
+                pUrl.setType(PortletUrlType.RENDER);
+                pUrl.setWindowState(WindowState.MAXIMIZED.toString());
+                PortletUrlParameter param = new PortletUrlParameter();
+                param.setName("proxy.url");
+                param.getValue().add(u);
+                pUrl.getParam().add(param);
+                result.setPortletUrl(pUrl);
+                
+                new SearchUtil().updateUrls(u, request, whitelistRegexes);                
+                searchResults.add(result);
+            }
+        
+        } catch (IOException ex) {
+            log.error(ex.getMessage(),ex);
+        } catch (XPathExpressionException ex) {
+            log.error(ex.getMessage(),ex);
+        } catch (ParserConfigurationException ex) {
+            log.error(ex.getMessage(),ex);
+        } catch (SAXException ex) {
+            log.error(ex.getMessage(),ex);
+        }
+        
+        return searchResults;
+        
+    }    
+    
+    private String buildGsaUrl(SearchRequest searchQuery, EventRequest request) {
+        String searchTerms = "";
+        try {
+            searchTerms = URLEncoder.encode(searchQuery.getSearchTerms(), "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            log.warn("Search term cannot be converted to UTF-8",e);
+        }
+        
+        String gsa = request.getPreferences().getValue("gsaHost", "");
+        String collection = request.getPreferences().getValue("gsaCollection", "");
+        String frontend = request.getPreferences().getValue("gsaFrontend", "");
+        if (gsa.equals("") || collection.equals("") || frontend.equals("")) {
+            log.info("NOT Configured for search -- GSA:"+gsa+" -- COLLECTION:"+collection+" -- frontend:"+frontend);
+        }
+                
+        String searchBaseURL = "http://"+gsa+"/search?q="+searchTerms+"&site="+ collection +"&client="+frontend+"&output=xml_no_dtd";
+        log.debug(searchBaseURL); 
+        return searchBaseURL;
+    }
+}

--- a/src/main/java/org/jasig/portlet/proxy/search/ISearchService.java
+++ b/src/main/java/org/jasig/portlet/proxy/search/ISearchService.java
@@ -1,0 +1,16 @@
+package org.jasig.portlet.proxy.search;
+
+import javax.portlet.EventRequest;
+
+import org.jasig.portal.search.SearchRequest;
+import org.jasig.portal.search.SearchResults;
+
+public interface ISearchService {
+    
+    public void addSearchStrategy(ISearchStrategy strategy);
+    
+    public String[] getStrategyNames();
+
+    public SearchResults search(SearchRequest searchQuery, EventRequest request);
+
+}

--- a/src/main/java/org/jasig/portlet/proxy/search/ISearchStrategy.java
+++ b/src/main/java/org/jasig/portlet/proxy/search/ISearchStrategy.java
@@ -1,0 +1,17 @@
+package org.jasig.portlet.proxy.search;
+
+import java.util.List;
+
+import javax.portlet.EventRequest;
+
+import org.jasig.portal.search.SearchRequest;
+import org.jasig.portal.search.SearchResult;
+import org.jsoup.nodes.Document;
+
+public interface ISearchStrategy {
+
+    public String getStrategyName();
+    
+    public List<SearchResult> search(SearchRequest searchQuery, EventRequest request, Document document);
+
+}

--- a/src/main/java/org/jasig/portlet/proxy/search/util/SearchUtil.java
+++ b/src/main/java/org/jasig/portlet/proxy/search/util/SearchUtil.java
@@ -1,0 +1,52 @@
+package org.jasig.portlet.proxy.search.util;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.regex.Pattern;
+
+import javax.portlet.PortletRequest;
+import javax.portlet.PortletSession;
+
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.portlet.util.PortletUtils;
+
+public class SearchUtil {
+    protected final Logger log = LoggerFactory.getLogger(this.getClass());
+
+    public void updateUrls(final String searchResultUrl,
+            final PortletRequest request, String[] whitelistRegexes) {
+        final String REWRITTEN_URLS_KEY = "rewrittenUrls";
+        
+        // attempt to retrieve the list of rewritten URLs from the session
+        final PortletSession session = request.getPortletSession();
+        ConcurrentMap<String, String> rewrittenUrls;
+        synchronized (PortletUtils.getSessionMutex(session)) {
+            rewrittenUrls = (ConcurrentMap<String, String>) session
+                    .getAttribute(REWRITTEN_URLS_KEY);
+
+            // if the rewritten URLs list doesn't exist yet, create it
+            if (rewrittenUrls == null) {
+                rewrittenUrls = new ConcurrentHashMap<String, String>();
+                session.setAttribute(REWRITTEN_URLS_KEY, rewrittenUrls);
+            }
+        }
+
+        // if this URL matches our whitelist regex, rewrite it
+        // to pass through this portlet
+        for (String regex : whitelistRegexes) {
+            if (StringUtils.isNotBlank(regex)) {
+                final Pattern pattern = Pattern.compile(regex); // TODO share
+                                                                // compiled
+                                                                // regexes
+
+                if (pattern.matcher(searchResultUrl).find()) {
+                    // record that we've rewritten this URL
+                    rewrittenUrls.put(searchResultUrl, searchResultUrl);
+                    log.debug("added [" + searchResultUrl + "] to rewrittenUrls");
+                }
+            }
+        }
+    }
+}

--- a/src/main/webapp/WEB-INF/context/portlet/webproxy-portlet.xml
+++ b/src/main/webapp/WEB-INF/context/portlet/webproxy-portlet.xml
@@ -40,7 +40,19 @@
             </list>
         </property>
     </bean>
-
+    
+    <bean id="anchorSearchStrategy" class="org.jasig.portlet.proxy.search.AnchorSearchStrategy">
+    	<property name="contentSearchProvider" ref="contentSearchProvider" />
+    </bean>
+    
+    <bean id="gsaSearchStrategy" class="org.jasig.portlet.proxy.search.GsaSearchStrategy">
+    	<property name="contentSearchProvider" ref="contentSearchProvider" />
+    </bean>
+    
+    <bean id="contentSearchProvider" class="org.jasig.portlet.proxy.search.DefaultSearchService">
+        
+    </bean>
+    
     <util:map id="pageCharacterEncodings">
         <entry key="UTF-8" value="UTF-8 (standard for HTML5)"/>
         <entry key="Cp1252" value="ANSI/Windows-1252/Cp1252"/>

--- a/src/main/webapp/WEB-INF/jsp/editProxyPortlet.jsp
+++ b/src/main/webapp/WEB-INF/jsp/editProxyPortlet.jsp
@@ -112,6 +112,37 @@
                     <form:textarea path="footer" rows="5" cols="80"/>
                 </p>
 
+                <p>
+                    <label>Page Search Strategies</label><br>
+                    <form:checkboxes path="searchStrategies" items="${strategyNames }" />
+                </p>
+                
+                <p>
+                    <label>Google Search Appliance Host</label><br>
+                    <form:input path="gsaHost" type="text" size="80"/>
+                </p>
+                
+                <p>
+                    <label>Google Search Appliance Collection</label><br>
+                    <form:input path="gsaCollection" type="text" size="80"/>
+                </p>
+                
+                <p>
+                    <label>Google Search Appliance Frontend</label><br>
+                    <form:input path="gsaFrontend" type="text" size="80"/>
+                </p>
+                
+                <p>
+                    <label>Google Search Appliance Whitelist Regex</label><br>
+                    <form:input path="gsaWhitelistRegex" type="text" size="80"/>
+                </p>
+                
+                <p>
+                    <label>Anchor Strategy Whitelist Regex</label><br>
+                    <form:input path="anchorWhitelistRegex" type="text" size="80"/>
+                </p>
+                
+                					                
                 <div class="buttons">
                     <input class="button primary" type="submit" name="Save" value="<spring:message code="save"/>"/>
                     <input class="button" type="submit" name="Cancel" value="<spring:message code="edit.proxy.cancel"/>"/>

--- a/src/main/webapp/WEB-INF/portlet.xml
+++ b/src/main/webapp/WEB-INF/portlet.xml
@@ -69,6 +69,13 @@
                 <value>UTF-8</value>
             </preference>
         </portlet-preferences>
+        
+        <supported-processing-event>
+            <qname xmlns:x="https://source.jasig.org/schemas/uportal/search">x:SearchRequest</qname>
+        </supported-processing-event>
+        <supported-publishing-event>
+            <qname xmlns:x="https://source.jasig.org/schemas/uportal/search">x:SearchResults</qname>
+        </supported-publishing-event>
     </portlet>
 
     <portlet>
@@ -145,6 +152,7 @@
             <role-name>Students</role-name>
             <role-link>Students</role-link>
         </security-role-ref>
+        
 
     </portlet>
 
@@ -152,5 +160,14 @@
         <description>CAS Proxy Ticket</description>
         <name>casProxyTicket</name>
     </user-attribute>
+ 
+    <event-definition>
+        <qname xmlns:x="https://source.jasig.org/schemas/uportal/search">x:SearchRequest</qname>
+        <value-type>org.jasig.portal.search.SearchRequest</value-type>
+    </event-definition>
+    <event-definition>
+        <qname xmlns:x="https://source.jasig.org/schemas/uportal/search">x:SearchResults</qname>
+        <value-type>org.jasig.portal.search.SearchResults</value-type>
+    </event-definition>
    
 </portlet-app>


### PR DESCRIPTION
This commit sets up the infrastructure for including WebProxyPortlets into the standard search.  Two strategies have been added for searching content.  One is AnchorSearchStrategy which takes the WebProxyPortlet location URL source, examines all of its links, and adds links that match the search criteria to the results.  The second is GsaSearchStrategy, which allows an external GoogleSearchAppliance to be linked to the WPP and queried as well.  A WPP can be configured without either of these strategies, and no results will be returned for this WPP instance.  Additional strategies can be added, for example to inspect content of the WPP page itself or to perhaps use search capabilities afforded by the WPP location's site.