### PR TITLE
WPP-95 - 2nd pass : vulnability library was reintroduced from portlet…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -291,22 +291,29 @@
             <groupId>taglibs</groupId>
             <artifactId>standard</artifactId>
         </dependency>
-        <dependency> 
-            <groupId>org.jasypt</groupId> 
-            <artifactId>jasypt</artifactId>  
+        <dependency>
+            <groupId>org.jasypt</groupId>
+            <artifactId>jasypt</artifactId>
             <version>1.6</version>
         </dependency>
-               
+
         <dependency>
             <groupId>org.jasig.portal</groupId>
             <artifactId>uportal-search-api</artifactId>
         </dependency>
-        
+
         <dependency>
             <groupId>org.jasig.portlet.utils</groupId>
             <artifactId>portlet-mvc-util</artifactId>
             <version>${portlet.mvc.util.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.hibernate</groupId>
+                    <artifactId>hibernate-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
+
         <!-- ===== Runtime Dependencies ================================== -->
         <dependency>
             <groupId>org.jasig.resourceserver</groupId>
@@ -402,6 +409,11 @@
                                 <requireJavaVersion>
                                     <version>1.6</version>
                                 </requireJavaVersion>
+                                <bannedDependencies>
+                                    <excludes>
+                                        <exclude>commons-collections:commons-collections:[3.0,3.2.1],[4.0]</exclude>
+                                    </excludes>
+                                </bannedDependencies>
                             </rules>
                         </configuration>
                     </execution>
@@ -470,7 +482,7 @@
             </plugin>
         </plugins>
     </build>
-    
+
     <profiles>
         <profile>
             <id>localdev</id>
@@ -514,5 +526,5 @@
             </build>
         </profile>
     </profiles>
-    
+
 </project>


### PR DESCRIPTION
…-mvc-utils

This commit fix the problem and introduce a check to avoid again such include from trnasitive library

It would be great to include this check in all projects, or use a plugin that check all vulnerabilities like :
https://github.com/jeremylong/DependencyCheck, other exists ;)
