### PR TITLE
WPP99 - SNI support with httpclient lib

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -17,15 +17,15 @@ under the License.
 
 This project includes:
   AOP alliance under Public Domain
-  Commons Codec under The Apache Software License, Version 2.0
+  Apache Commons Codec under The Apache Software License, Version 2.0
+  Apache HttpClient under Apache License, Version 2.0
+  Apache HttpCore under Apache License, Version 2.0
   Commons IO under The Apache Software License, Version 2.0
   Commons Logging under The Apache Software License, Version 2.0
   Ehcache Core under The Apache Software License, Version 2.0
   Ehcache Web Filters under The Apache Software License, Version 2.0
   Guava: Google Core Libraries for Java under The Apache Software License, Version 2.0
   Hamcrest Core under BSD style
-  HttpClient under Apache License
-  HttpCore under Apache License
   Jackson-annotations under The Apache Software License, Version 2.0
   Jackson-core under The Apache Software License, Version 2.0
   jackson-databind under The Apache Software License, Version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
-                <version>4.2</version>
+                <version>4.5.2</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>

--- a/src/main/java/org/jasig/portlet/proxy/service/web/HttpContentRequestImpl.java
+++ b/src/main/java/org/jasig/portlet/proxy/service/web/HttpContentRequestImpl.java
@@ -29,6 +29,8 @@ import javax.portlet.PortletRequest;
 import javax.portlet.PortletSession;
 import javax.portlet.WindowState;
 
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.protocol.HttpContext;
 import org.jasig.portlet.proxy.service.GenericContentRequestImpl;
 import org.jasig.portlet.proxy.service.IFormField;
 import org.jasig.portlet.proxy.service.proxy.document.URLRewritingFilter;
@@ -44,6 +46,7 @@ public class HttpContentRequestImpl extends GenericContentRequestImpl {
     private Map<String, String> headers = new HashMap<String, String>();
     private String method;
     private boolean isForm;
+    private HttpContext httpContext;
 
     public HttpContentRequestImpl() {
     }
@@ -92,6 +95,8 @@ public class HttpContentRequestImpl extends GenericContentRequestImpl {
 
         this.isForm = Boolean.valueOf(request.getParameter(HttpContentServiceImpl.IS_FORM_PARAM));
         this.method = request.getParameter(HttpContentServiceImpl.FORM_METHOD_PARAM);
+
+        this.httpContext = HttpClientContext.create();
 
     }
 
@@ -147,6 +152,14 @@ public class HttpContentRequestImpl extends GenericContentRequestImpl {
         this.isForm = isForm;
     }
 
+    public HttpContext getHttpContext() {
+        return httpContext;
+    }
+
+    public void setHttpContext(HttpContext httpContext) {
+        this.httpContext = httpContext;
+    }
+
     /**
      * duplicate() creates a duplicate of the HttpContentRequest without
      * using clone().  All objects are unique, but the data contained within
@@ -158,6 +171,7 @@ public class HttpContentRequestImpl extends GenericContentRequestImpl {
         copy.setMethod(this.getMethod());
         copy.setForm(this.isForm());
         copy.setProxiedLocation(this.getProxiedLocation());
+        copy.setHttpContext(this.getHttpContext());
 
         Map<String, String> copyHeaders = new LinkedHashMap<String, String>();
         copyHeaders.putAll(this.headers);

--- a/src/main/java/org/jasig/portlet/proxy/service/web/HttpContentServiceImpl.java
+++ b/src/main/java/org/jasig/portlet/proxy/service/web/HttpContentServiceImpl.java
@@ -35,15 +35,13 @@ import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.HttpClient;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.utils.URIBuilder;
-import org.apache.http.impl.client.AbstractHttpClient;
 import org.apache.http.message.BasicNameValuePair;
-import org.apache.http.protocol.BasicHttpContext;
-import org.apache.http.protocol.HttpContext;
 import org.jasig.portlet.proxy.service.GenericContentResponseImpl;
 import org.jasig.portlet.proxy.service.IContentService;
 import org.jasig.portlet.proxy.service.IFormField;
@@ -132,7 +130,7 @@ public class HttpContentServiceImpl implements IContentService<HttpContentReques
 
             // get an HttpClient appropriate for this user and portlet instance
             // and set any basic auth credentials, if applicable
-            final AbstractHttpClient httpclient = httpClientService.getHttpClient(request);
+            final HttpClient httpclient = httpClientService.getHttpClient(request);
 
             // create the request
             final HttpUriRequest httpRequest = getHttpRequest(proxyRequest, request);
@@ -141,8 +139,7 @@ public class HttpContentServiceImpl implements IContentService<HttpContentReques
             }
 
             // execute the request
-            final HttpContext context = new BasicHttpContext();
-            final HttpResponse response = httpclient.execute(httpRequest, context);
+            final HttpResponse response = httpclient.execute(httpRequest, proxyRequest.getHttpContext());
             final HttpEntity entity = response.getEntity();
 
             // create the response object and set the content stream
@@ -155,7 +152,7 @@ public class HttpContentServiceImpl implements IContentService<HttpContentReques
             }
 
             // set the final URL of the response in case it was redirected
-            String finalUrl = (String) context.getAttribute(RedirectTrackingResponseInterceptor.FINAL_URL_KEY);
+            String finalUrl = (String) proxyRequest.getHttpContext().getAttribute(RedirectTrackingResponseInterceptor.FINAL_URL_KEY);
             if (finalUrl == null) {
                 finalUrl = proxyRequest.getProxiedLocation();
             }

--- a/src/main/java/org/jasig/portlet/proxy/service/web/IHttpClientService.java
+++ b/src/main/java/org/jasig/portlet/proxy/service/web/IHttpClientService.java
@@ -20,10 +20,9 @@ package org.jasig.portlet.proxy.service.web;
 
 import javax.portlet.PortletRequest;
 
-import org.apache.http.impl.client.AbstractHttpClient;
+import org.apache.http.client.HttpClient;
 
 public interface IHttpClientService {
 	
-	public AbstractHttpClient getHttpClient(PortletRequest portletRequest);
-
+	HttpClient getHttpClient(PortletRequest portletRequest);
 }

--- a/src/main/java/org/jasig/portlet/proxy/service/web/MultiRequestHttpClientServiceImpl.java
+++ b/src/main/java/org/jasig/portlet/proxy/service/web/MultiRequestHttpClientServiceImpl.java
@@ -41,11 +41,13 @@ import org.springframework.web.portlet.util.PortletUtils;
 public class MultiRequestHttpClientServiceImpl implements IHttpClientService {
     private static final Logger LOG = LoggerFactory.getLogger(MultiRequestHttpClientServiceImpl.class);
     private static final String HTTP_CLIENT_CONNECTION_TIMEOUT = "httpClientConnectionTimeout";
+    private static final String HTTP_CLIENT_CONNECTION_REQUEST_TIMEOUT = "httpClientConnectionRequestTimeout";
     private static final String HTTP_CLIENT_SOCKET_TIMEOUT = "httpClientSocketTimeout";
     private static final int DEFAULT_HTTP_CLIENT_CONNECTION_TIMEOUT = 10000;
+    private static final int DEFAULT_HTTP_CLIENT_CONNECTION_REQUEST_TIMEOUT = 5000;
     private static final int DEFAULT_HTTP_CLIENT_SOCKET_TIMEOUT = 10000;
-    protected static final String          CLIENT_SESSION_KEY = "httpClient";
-    protected static final String          SHARED_SESSION_KEY = "sharedSessionKey";
+    protected static final String CLIENT_SESSION_KEY = "httpClient";
+    protected static final String SHARED_SESSION_KEY = "sharedSessionKey";
 
     @Override
     public HttpClient getHttpClient(PortletRequest request) {
@@ -84,10 +86,11 @@ public class MultiRequestHttpClientServiceImpl implements IHttpClientService {
     protected HttpClient createHttpClient(PortletRequest request) {
         PortletPreferences prefs = request.getPreferences();
         int httpClientConnectionTimeout = Integer.parseInt(prefs.getValue(HTTP_CLIENT_CONNECTION_TIMEOUT, String.valueOf(DEFAULT_HTTP_CLIENT_CONNECTION_TIMEOUT)));
+        int httpClientConnectionRequestTimeout = Integer.parseInt(prefs.getValue(HTTP_CLIENT_CONNECTION_REQUEST_TIMEOUT, String.valueOf(DEFAULT_HTTP_CLIENT_CONNECTION_REQUEST_TIMEOUT)));
         int httpClientSocketTimeout = Integer.parseInt(prefs.getValue(HTTP_CLIENT_SOCKET_TIMEOUT, String.valueOf(DEFAULT_HTTP_CLIENT_SOCKET_TIMEOUT)));
         RequestConfig config = RequestConfig.custom()
                 .setConnectTimeout(httpClientConnectionTimeout)
-                //.setConnectionRequestTimeout(????)
+                .setConnectionRequestTimeout(httpClientConnectionRequestTimeout)
                 .setSocketTimeout(httpClientSocketTimeout).build();
         final HttpClient client = HttpClientBuilder.create()
                 .setDefaultRequestConfig(config)

--- a/src/main/java/org/jasig/portlet/proxy/service/web/MultiRequestHttpClientServiceImpl.java
+++ b/src/main/java/org/jasig/portlet/proxy/service/web/MultiRequestHttpClientServiceImpl.java
@@ -40,14 +40,14 @@ import org.springframework.web.portlet.util.PortletUtils;
 @Service
 public class MultiRequestHttpClientServiceImpl implements IHttpClientService {
     private static final Logger LOG = LoggerFactory.getLogger(MultiRequestHttpClientServiceImpl.class);
-    private static final String HTTP_CLIENT_CONNECTION_TIMEOUT = "httpClientConnectionTimeout";
-    private static final String HTTP_CLIENT_CONNECTION_REQUEST_TIMEOUT = "httpClientConnectionRequestTimeout";
-    private static final String HTTP_CLIENT_SOCKET_TIMEOUT = "httpClientSocketTimeout";
-    private static final int DEFAULT_HTTP_CLIENT_CONNECTION_TIMEOUT = 10000;
-    private static final int DEFAULT_HTTP_CLIENT_CONNECTION_REQUEST_TIMEOUT = 5000;
-    private static final int DEFAULT_HTTP_CLIENT_SOCKET_TIMEOUT = 10000;
-    protected static final String CLIENT_SESSION_KEY = "httpClient";
-    protected static final String SHARED_SESSION_KEY = "sharedSessionKey";
+    public static final String HTTP_CLIENT_CONNECTION_TIMEOUT = "httpClientConnectionTimeout";
+    public static final String HTTP_CLIENT_CONNECTION_REQUEST_TIMEOUT = "httpClientConnectionRequestTimeout";
+    public static final String HTTP_CLIENT_SOCKET_TIMEOUT = "httpClientSocketTimeout";
+    public static final int DEFAULT_HTTP_CLIENT_CONNECTION_TIMEOUT = 10000;
+    public static final int DEFAULT_HTTP_CLIENT_CONNECTION_REQUEST_TIMEOUT = 5000;
+    public static final int DEFAULT_HTTP_CLIENT_SOCKET_TIMEOUT = 10000;
+    public static final String CLIENT_SESSION_KEY = "httpClient";
+    public static final String SHARED_SESSION_KEY = "sharedSessionKey";
 
     @Override
     public HttpClient getHttpClient(PortletRequest request) {

--- a/src/main/java/org/jasig/portlet/proxy/service/web/interceptor/AbstractBasicAuthenticationPreInterceptor.java
+++ b/src/main/java/org/jasig/portlet/proxy/service/web/interceptor/AbstractBasicAuthenticationPreInterceptor.java
@@ -23,7 +23,7 @@ import javax.portlet.PortletRequest;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.Credentials;
 import org.apache.http.client.CredentialsProvider;
-import org.apache.http.impl.client.AbstractHttpClient;
+import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.jasig.portlet.proxy.service.web.HttpContentRequestImpl;
 import org.jasig.portlet.proxy.service.web.IHttpClientService;
@@ -66,8 +66,10 @@ public abstract class AbstractBasicAuthenticationPreInterceptor extends Authenti
 		// not limited to the session of the target website, so these credentials
 		// may be applied more than once.  We expect these periodic updates to 
 		// be unnecessary but do not expect them to cause any problems.
-		final AbstractHttpClient client = httpClientService.getHttpClient(portletRequest);
-		client.setCredentialsProvider(credentialsProvider);
+		final HttpClientContext context = HttpClientContext.create();
+		context.setCredentialsProvider(credentialsProvider);
+
+		contentRequest.setHttpContext(context);
 	}
 
 	/**

--- a/src/test/java/org/jasig/portlet/proxy/service/web/HttpContentRequestImplTest.java
+++ b/src/test/java/org/jasig/portlet/proxy/service/web/HttpContentRequestImplTest.java
@@ -20,9 +20,11 @@ package org.jasig.portlet.proxy.service.web;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
+
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import org.apache.http.client.protocol.HttpClientContext;
 import org.jasig.portlet.proxy.service.IFormField;
 import org.junit.Before;
 import org.junit.Test;
@@ -55,7 +57,10 @@ public class HttpContentRequestImplTest {
 		final String originalParameterValue1 = "A";
 		final String originalParameterValue2 = "B";
 		final String newParameterValue1 = "99";
-		
+
+		final HttpClientContext originalHttpClientContext = HttpClientContext.create();
+		final HttpClientContext newHttpClientContext = HttpClientContext.create();
+
 		Map<String, IFormField> parameters = new LinkedHashMap<String, IFormField>();
 		IFormField parameter = new FormFieldImpl();
 		parameter.setName(originalParameterKey);
@@ -72,6 +77,7 @@ public class HttpContentRequestImplTest {
 		original.setMethod(originalMethod);
 		original.setHeaders(headers);
 		original.setParameters(parameters);
+		original.setHttpContext(originalHttpClientContext);
 		
 		HttpContentRequestImpl copy = original.duplicate();
 		
@@ -79,6 +85,7 @@ public class HttpContentRequestImplTest {
 		assertEquals(copy.getMethod(), originalMethod);
 		assertEquals(copy.getProxiedLocation(), originalProxiedLocation);
 		assertEquals(copy.getHeaders().get(originalHeaderKey), originalHeaderValue);
+		assertEquals(copy.getHttpContext(), originalHttpClientContext);
 		IFormField copyParameter = copy.getParameters().get(originalParameterKey);
 		assertEquals(copyParameter.getValues()[0], originalParameterValue1);
 		assertEquals(copyParameter.getValues()[1], originalParameterValue2);
@@ -86,6 +93,7 @@ public class HttpContentRequestImplTest {
 		original.setForm(false);
 		original.setProxiedLocation(newProxiedLocation);
 		original.setMethod(newMethod);
+		original.setHttpContext(newHttpClientContext);
 		IFormField originalParameter = original.getParameters().get(originalParameterKey);
 		originalParameter.getValues()[0] = newParameterValue1;
 		original.getHeaders().put(originalHeaderKey, newHeaderValue);
@@ -93,6 +101,7 @@ public class HttpContentRequestImplTest {
 		assertNotSame(original.isForm(), copy.isForm());
 		assertNotSame(original.getMethod(), copy.getMethod());
 		assertNotSame(original.getProxiedLocation(), copy.getProxiedLocation());
+		assertNotSame(original.getHttpContext(), copy.getHttpContext());
 		assertNotSame(original.getParameters().get(originalParameterKey), copy.getParameters().get(originalParameterKey));
 		assertNotSame(original.getHeaders().get(originalHeaderKey), copy.getHeaders().get(originalHeaderKey));
 	}

--- a/src/test/java/org/jasig/portlet/proxy/service/web/MultiRequestHttpClientServiceImplTest.java
+++ b/src/test/java/org/jasig/portlet/proxy/service/web/MultiRequestHttpClientServiceImplTest.java
@@ -20,29 +20,25 @@ package org.jasig.portlet.proxy.service.web;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
-import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import javax.portlet.PortletPreferences;
 import javax.portlet.PortletRequest;
 import javax.portlet.PortletSession;
 
 import org.apache.http.client.HttpClient;
-import org.apache.http.impl.client.DefaultHttpClient;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 public class MultiRequestHttpClientServiceImplTest {
-    private static final String HTTP_CLIENT_CONNECTION_TIMEOUT = "httpClientConnectionTimeout";
-    private static final String HTTP_CLIENT_SOCKET_TIMEOUT = "httpClientSocketTimeout";
-    private static final int DEFAULT_HTTP_CLIENT_CONNECTION_TIMEOUT = 10000;
-    private static final int DEFAULT_HTTP_CLIENT_SOCKET_TIMEOUT = 10000;
+
 	@Mock PortletRequest request;
 	@Mock PortletPreferences preferences;
 	@Mock PortletSession session;
-	@Mock DefaultHttpClient client;
+	@Mock HttpClient client;
 	MultiRequestHttpClientServiceImpl service;
 	
 	@Before
@@ -53,8 +49,15 @@ public class MultiRequestHttpClientServiceImplTest {
 		
 		when(request.getPreferences()).thenReturn(preferences);
 		when(request.getPortletSession()).thenReturn(session);
-		when(preferences.getValue(HTTP_CLIENT_CONNECTION_TIMEOUT, String.valueOf(DEFAULT_HTTP_CLIENT_CONNECTION_TIMEOUT))).thenReturn(String.valueOf(DEFAULT_HTTP_CLIENT_CONNECTION_TIMEOUT));
-		when(preferences.getValue(HTTP_CLIENT_SOCKET_TIMEOUT, String.valueOf(DEFAULT_HTTP_CLIENT_SOCKET_TIMEOUT))).thenReturn(String.valueOf(DEFAULT_HTTP_CLIENT_SOCKET_TIMEOUT));
+		when(preferences.getValue(MultiRequestHttpClientServiceImpl.HTTP_CLIENT_CONNECTION_TIMEOUT,
+				String.valueOf(MultiRequestHttpClientServiceImpl.DEFAULT_HTTP_CLIENT_CONNECTION_TIMEOUT)))
+				.thenReturn(String.valueOf(MultiRequestHttpClientServiceImpl.DEFAULT_HTTP_CLIENT_CONNECTION_TIMEOUT));
+		when(preferences.getValue(MultiRequestHttpClientServiceImpl.HTTP_CLIENT_CONNECTION_REQUEST_TIMEOUT,
+				String.valueOf(MultiRequestHttpClientServiceImpl.DEFAULT_HTTP_CLIENT_CONNECTION_REQUEST_TIMEOUT)))
+				.thenReturn(String.valueOf(MultiRequestHttpClientServiceImpl.DEFAULT_HTTP_CLIENT_CONNECTION_REQUEST_TIMEOUT));
+		when(preferences.getValue(MultiRequestHttpClientServiceImpl.HTTP_CLIENT_SOCKET_TIMEOUT,
+				String.valueOf(MultiRequestHttpClientServiceImpl.DEFAULT_HTTP_CLIENT_SOCKET_TIMEOUT)))
+				.thenReturn(String.valueOf(MultiRequestHttpClientServiceImpl.DEFAULT_HTTP_CLIENT_SOCKET_TIMEOUT));
 	}
 
 	


### PR DESCRIPTION
Upgrade of the HttpClient from 4.2 to 4.5.2. This is solving SNI bug problems and HttpClient can be more configurable.

Just a warning the current use of the httpclient can be made on a better way with this new version and will improve the configuration possibilities.
Also the configuration by default use a PooledConnection, just need some customization.
