### PR TITLE
Add `overlays` to `.gitignore`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /*.iml
 .idea
 .springBeans
+overlays


### PR DESCRIPTION
Makes the `.gitignore` slightly more IntelliJ-IDEA friendly.