### PR TITLE
Add codeclimate.com badges to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 # Web Proxy Portlet
 
+[![Code Climate](https://codeclimate.com/github/Jasig/WebproxyPortlet/badges/gpa.svg)](https://codeclimate.com/github/Jasig/WebproxyPortlet) 
+[![codeclimate.com Issue Count](https://codeclimate.com/github/Jasig/WebproxyPortlet/badges/issue_count.svg)](https://codeclimate.com/github/Jasig/WebproxyPortlet)
+
+
 [Link to old documentation](https://wiki.jasig.org/display/PLT/WebProxy)
 
 ## Table of Contents


### PR DESCRIPTION
Adds a couple shiny badges.

This serves to document that codeclimate.com is computing code climate reports on `WebproxyPortlet`, by linking to those reports.

Could go further and invite `codeclimate.com` to comment on Pull Requests e.g. drawing attention to whether a proposed changeset seems to improve or erode the code climate.