### PR TITLE
WPP-104 Values in rewritten urls map need to be resource urls

### DIFF
--- a/src/main/java/org/jasig/portlet/proxy/service/proxy/document/URLRewritingFilter.java
+++ b/src/main/java/org/jasig/portlet/proxy/service/proxy/document/URLRewritingFilter.java
@@ -193,11 +193,7 @@ public class URLRewritingFilter implements IDocumentFilter {
                           if (pattern.matcher(attributeUrl).find()) {
 
                               // record that we've rewritten this URL
-                              rewrittenUrls.put(attributeUrl, attributeUrl);
-
-                              // TODO: the value in the rewritten URLs map needs to 
-                              // be a resource URL.  we also want to key URLs by a short
-                              // string rather than the full URL
+                              rewrittenUrls.put(attributeUrl, createResourceUrl(response, attributeUrl));
 
                               if (elementEntry.getKey().equals("form")) {
                                   // the form action needs to be set to POST to

--- a/src/test/java/org/jasig/portlet/proxy/service/proxy/document/URLRewritingFilterTest.java
+++ b/src/test/java/org/jasig/portlet/proxy/service/proxy/document/URLRewritingFilterTest.java
@@ -97,6 +97,7 @@ public class URLRewritingFilterTest {
     public void testProxiedUrls() {
         when(preferences.getValues(URLRewritingFilter.WHITELIST_REGEXES_KEY, new String[]{})).thenReturn(new String[]{"^http://external.site.com"});
         doReturn("portletUrl").when(filter).createActionUrl(any(RenderResponse.class), any(String.class));        
+        doReturn("portletUrl").when(filter).createResourceUrl(any(RenderResponse.class), any(String.class));
         
         final Document document = Jsoup.parse("<div><a href=\"/link/with/slash.html\">Link</a><a href=\"link/without/slash.html\">Link</a></div>");
         filter.filter(document, proxyResponse, request, response);


### PR DESCRIPTION
The [TODO](https://github.com/Jasig/WebproxyPortlet/pull/28/files#diff-721cbbde9a2c28077ef38d3e07048898L198) wasn't lying.

The rewritten url map is used when looking at an action url's return content type.  If it's something like `pdf`, it then redirects the browser to the url in the map.  As of now, it doesn't work when the url is behind something like a firewall where the content needs to be proxied, but it does work when the content isn't behind a firewall.   Now it will work for both.