### PR TITLE
chore: drop redundant doclint-java8-disable profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -394,24 +394,6 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-              <id>doclint-java8-disable</id>
-              <activation>
-                  <jdk>[1.8,)</jdk>
-              </activation>
-              <build>
-                  <plugins>
-                      <plugin>
-                          <groupId>org.apache.maven.plugins</groupId>
-                          <artifactId>maven-javadoc-plugin</artifactId>
-                          <version>3.11.2</version>
-                          <configuration>
-                              <doclint>none</doclint>
-                          </configuration>
-                      </plugin>
-                  </plugins>
-              </build>
-          </profile>
     </profiles>
 
     <reporting>


### PR DESCRIPTION
## Summary

The `doclint-java8-disable` profile scoped a local `maven-javadoc-plugin` block with `<doclint>none</doclint>`. Both the plugin version (3.11.2) and the `doclint=none` setting are already provided by `uportal-portlet-parent:48` in its `pluginManagement`. The local override duplicated parent config.

The profile activated on `<jdk>[1.8,)</jdk>` — i.e., always, since this portlet runs on Java 11.

**Supersedes #257** (which was trying to bump the now-deleted block 3.11.2 → 3.12.0). Future javadoc-plugin bumps flow through the parent.

## Test plan

- [x] `mvn validate` passes
- [x] `mvn help:effective-pom` confirms `maven-javadoc-plugin:3.11.2` with `<doclint>none</doclint>` and the `attach-javadocs` execution resolve from parent after this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)