### PR TITLE
chore: bump parent v49 → v50 for plexus-archiver CVE fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.jasig.portlet</groupId>
         <artifactId>uportal-portlet-parent</artifactId>
-        <version>49</version>
+        <version>50</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.jasig.portlet</groupId>
         <artifactId>uportal-portlet-parent</artifactId>
-        <version>50</version>
+        <version>51</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/src/main/java/org/jasig/portlet/proxy/mvc/portlet/gateway/GatewayPortletController.java
+++ b/src/main/java/org/jasig/portlet/proxy/mvc/portlet/gateway/GatewayPortletController.java
@@ -18,7 +18,7 @@
  */
 package org.jasig.portlet.proxy.mvc.portlet.gateway;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jasig.portlet.proxy.mvc.IViewSelector;
 import org.jasig.portlet.proxy.service.IFormField;
 import org.jasig.portlet.proxy.service.web.HttpContentRequestImpl;

--- a/src/main/java/org/jasig/portlet/proxy/mvc/portlet/gateway/GatewayPortletEditController.java
+++ b/src/main/java/org/jasig/portlet/proxy/mvc/portlet/gateway/GatewayPortletEditController.java
@@ -31,7 +31,7 @@ import javax.portlet.PortletPreferences;
 import javax.portlet.RenderRequest;
 import javax.portlet.WindowState;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jasig.portlet.proxy.mvc.IViewSelector;
 import org.jasig.portlet.proxy.mvc.portlet.utilities.ActionScopedRequestAttributeManager;
 import org.jasig.portlet.proxy.security.IStringEncryptionService;

--- a/src/main/java/org/jasig/portlet/proxy/mvc/portlet/proxy/EditProxyController.java
+++ b/src/main/java/org/jasig/portlet/proxy/mvc/portlet/proxy/EditProxyController.java
@@ -30,7 +30,7 @@ import javax.portlet.PortletModeException;
 import javax.portlet.PortletPreferences;
 import javax.portlet.PortletRequest;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jasig.portlet.proxy.search.ISearchService;
 import org.jasig.portlet.proxy.service.GenericContentRequestImpl;
 import org.jasig.portlet.proxy.service.proxy.document.ContentClippingFilter;

--- a/src/main/java/org/jasig/portlet/proxy/search/util/SearchUtil.java
+++ b/src/main/java/org/jasig/portlet/proxy/search/util/SearchUtil.java
@@ -25,7 +25,7 @@ import java.util.regex.Pattern;
 import javax.portlet.PortletRequest;
 import javax.portlet.PortletSession;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.portlet.util.PortletUtils;

--- a/src/main/java/org/jasig/portlet/proxy/service/proxy/document/HeaderFooterFilter.java
+++ b/src/main/java/org/jasig/portlet/proxy/service/proxy/document/HeaderFooterFilter.java
@@ -22,7 +22,7 @@ import javax.portlet.PortletPreferences;
 import javax.portlet.RenderRequest;
 import javax.portlet.RenderResponse;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jasig.portlet.proxy.service.IContentResponse;
 import org.jsoup.nodes.Document;
 import org.springframework.stereotype.Service;

--- a/src/main/java/org/jasig/portlet/proxy/service/proxy/document/URLRewritingFilter.java
+++ b/src/main/java/org/jasig/portlet/proxy/service/proxy/document/URLRewritingFilter.java
@@ -33,7 +33,7 @@ import javax.portlet.RenderRequest;
 import javax.portlet.RenderResponse;
 import javax.portlet.ResourceURL;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.utils.URIBuilder;
 import org.jasig.portlet.proxy.service.IContentResponse;
 import org.jasig.portlet.proxy.service.web.HttpContentServiceImpl;

--- a/src/main/java/org/jasig/portlet/proxy/service/web/interceptor/PortletPreferencesBasicAuthenticationPreInterceptor.java
+++ b/src/main/java/org/jasig/portlet/proxy/service/web/interceptor/PortletPreferencesBasicAuthenticationPreInterceptor.java
@@ -22,7 +22,7 @@ package org.jasig.portlet.proxy.service.web.interceptor;
 import javax.portlet.PortletPreferences;
 import javax.portlet.PortletRequest;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/org/jasig/portlet/proxy/service/web/interceptor/UserPreferencesPreInterceptor.java
+++ b/src/main/java/org/jasig/portlet/proxy/service/web/interceptor/UserPreferencesPreInterceptor.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import javax.portlet.PortletPreferences;
 import javax.portlet.PortletRequest;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jasig.portlet.proxy.security.IStringEncryptionService;
 import org.jasig.portlet.proxy.service.IFormField;
 import org.jasig.portlet.proxy.service.web.HttpContentRequestImpl;


### PR DESCRIPTION
Bumps to [uportal-portlet-parent:50](https://github.com/uPortal-Project/uportal-portlet-parent/releases/tag/uportal-portlet-parent-50), which patches **CVE-2023-37460** (plexus-archiver Arbitrary File Creation in AbstractUnArchiver, CVSS 8.1 HIGH) by bumping its bundled `maven-war-plugin` 3.4.0 → 3.5.1 (which carries plexus-archiver 4.10.4, patched).

Real-world risk for portlet builds is low — we use plexus-archiver to *create* WARs, not extract untrusted archives — but the parent shouldn't ship a known-vulnerable transitive by default.

## Test plan

- [x] `mvn clean install license:check -Dgpg.skip=true` — green
- [ ] CI on Java 11 matrix