### PR TITLE
refactor: path-swap to /resource-server/ + drop resource-server-content overlay

### DIFF
--- a/docs/gateway_config.md
+++ b/docs/gateway_config.md
@@ -109,7 +109,7 @@ The description of the portlet itself lives in the portlet definition file:
             custom operations, in this case to also set the window name to the calculated field.
         -->
         <bean class="org.jasig.portlet.proxy.mvc.portlet.gateway.GatewayEntry" p:name="MyZimbra"
-              p:iconUrl="/ResourceServingWebapp/rs/tango/0.8.90/32x32/apps/internet-mail.png"
+              p:iconUrl="/resource-server/rs/tango/0.8.90/32x32/apps/internet-mail.png"
               p:javascriptFile="/WebProxyPortlet/scripts/custom-javascript.js">
 
             <!-- Custom java form fields.  Beans in list must implement org.jasig.portlet.proxy.mvc.service.web.IAuthenticationFormModifier
@@ -273,7 +273,7 @@ This is how you might add IAuthenticationFormModifier to your portlet definition
 
   ```
           <bean class="org.jasig.portlet.proxy.mvc.portlet.gateway.GatewayEntry" p:name="MyZimbra"
-              p:iconUrl="/ResourceServingWebapp/rs/tango/0.8.90/32x32/apps/internet-mail.png">
+              p:iconUrl="/resource-server/rs/tango/0.8.90/32x32/apps/internet-mail.png">
 
             <property name="authenticationFormModifier">
                 <util:list>
@@ -302,7 +302,7 @@ GatewayEntry bean; e.g.
 
   ```
 <bean class="org.jasig.portlet.proxy.mvc.portlet.gateway.GatewayEntry" p:name="WebAdvisor"
-      p:iconUrl="/ResourceServingWebapp/rs/tango/0.8.90/32x32/apps/internet-web-browser.png"
+      p:iconUrl="/resource-server/rs/tango/0.8.90/32x32/apps/internet-web-browser.png"
       p:javascriptFile="/WebProxyPortlet/scripts/custom-javascript.js">
 ...
 </bean>

--- a/pom.xml
+++ b/pom.xml
@@ -154,12 +154,6 @@
             <version>${bouncycastle.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.jasig.resourceserver</groupId>
-            <artifactId>resource-server-content</artifactId>
-            <version>${resource-server.version}</version>
-            <type>war</type>
-        </dependency>
-        <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
             <version>1.22.2</version>
@@ -316,20 +310,6 @@
                     <attachClasses>true</attachClasses>
                     <warName>${project.artifactId}</warName>
                     <webXml>src/main/webapp/WEB-INF/web.xml</webXml>
-                    <overlays>
-                        <overlay>
-                            <groupId>org.jasig.resourceserver</groupId>
-                            <artifactId>resource-server-content</artifactId>
-                            <includes>
-				<include>rs/jquery/1.12.2/</include>
-                                <include>rs/jquery/1.11.0/</include>
-                                <include>/rs/jqueryui/1.8.24/</include>
-                                <include>/rs/famfamfam/silk/1.3/error.png</include>
-                                <include>/rs/famfamfam/silk/1.3/application_delete.png</include>
-                                <include>/rs/famfamfam/silk/1.3/application_edit.png</include>
-                            </includes>
-                        </overlay>
-                    </overlays>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/webapp/WEB-INF/context/portlet/gateway-sso-portlet.xml
+++ b/src/main/webapp/WEB-INF/context/portlet/gateway-sso-portlet.xml
@@ -58,7 +58,7 @@
          -->
         <!--
         <bean class="org.jasig.portlet.proxy.mvc.portlet.gateway.GatewayEntry" p:name="MyZimbra"
-              p:iconUrl="/ResourceServingWebapp/rs/tango/0.8.90/32x32/apps/internet-mail.png">
+              p:iconUrl="/resource-server/rs/tango/0.8.90/32x32/apps/internet-mail.png">
 
             <property name="contentRequests">
                 <util:map>
@@ -115,7 +115,7 @@
         -->
         <!--
         <bean class="org.jasig.portlet.proxy.mvc.portlet.gateway.GatewayEntry" p:name="WebAdvisor"
-              p:iconUrl="/ResourceServingWebapp/rs/tango/0.8.90/32x32/apps/internet-web-browser.png"
+              p:iconUrl="/resource-server/rs/tango/0.8.90/32x32/apps/internet-web-browser.png"
               p:javascriptFile="/WebProxyPortlet/scripts/custom-javascript.js">
 
             <!- beans in list must implement org.jasig.portlet.proxy.mvc.service.web.IAuthenticationFormModifier


### PR DESCRIPTION
## Summary

Two commits, both part of the broader resource-server consolidation:

1. **`45f30c2`** (prior) — path-swap legacy `/ResourceServingWebapp/` to `/resource-server/` across JSPs and Spring portlet config.
2. **`8197bc2`** (new) — drop the `resource-server-content` WAR overlay (dep + maven-war-plugin extract). The overlay was unpacking lodash 4.17.4 (4 CVEs), underscore, backbone, modernizr, normalize, and jquery-plugins into the WAR for nothing, plus an explicit extract of jquery 1.11.0/1.12.2, jqueryui 1.8.24, and 3 famfamfam silk PNGs.

## Why this is safe

- `gateway.jsp` and `gatewayEdit.jsp` consume the famfamfam PNGs via `<rs:resourceURL value="/rs/famfamfam/..."/>`. The `rs:*` taglib does cross-context lookup against the resource-server context (uPortal-start's `resource-server-content` overlay still serves these). Local WAR copies were fallbacks the taglib never emitted.
- `gatewayNewPage.jsp` references `/resource-server/webjars/jquery/dist/jquery.min.js` directly — modern path, served by uPortal-start's resource-server overlay.
- `grep -rEn '/WebproxyPortlet/rs/' src/` returns no matches.

## Test plan

- [ ] `mvn clean install -DskipTests` builds (verified locally on Java 11)
- [ ] WAR has no `rs/` directory (verified)
- [ ] Smoke: `/p/gateway/?pCm=view` and `?pCm=edit` render with the icon thumbnails intact (icons resolve via uPortal-start's `/resource-server/rs/famfamfam/...`).

## Future cleanup

When uPortal-start drops `resource-server-content`, the JSP `<rs:resourceURL>` famfamfam refs need a swap (webjar or portlet-local checkout). Not in this PR's scope.